### PR TITLE
Upgrade CI build environment to ubuntu-22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             rust: stable
           - target: x86_64-apple-darwin
             os: macos-12
@@ -63,7 +63,7 @@ jobs:
           mkdir -p ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}_${{ matrix.target }}_${{ steps.get_version.outputs.VERSION }}
       
       - name: Move binaries (Linux/MacOS)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'macos-12'
+        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'macos-12'
         run: |
           mv ./target/${{ matrix.target }}/release/${{ env.RELEASE_BIN }} ${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}_${{ matrix.target }}_${{ steps.get_version.outputs.VERSION }}/${{ env.RELEASE_BIN }}
       
@@ -74,7 +74,7 @@ jobs:
           cp ./target/${{ matrix.target }}/release/${{ env.RELEASE_BIN }}.exe ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}_${{ matrix.target }}_${{ steps.get_version.outputs.VERSION }}/${{ env.RELEASE_BIN }}.exe
   
       - name: Create tarball (Linux)
-        if: matrix.os == 'ubuntu-20.04'
+        if: matrix.os == 'ubuntu-22.04'
         run: 7z a -ttar -so -an ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}_${{ matrix.target }}_${{ steps.get_version.outputs.VERSION }} | 7z a -si ./${{ env.RELEASE_DIR }}/${{ env.RELEASE_BIN }}_linux_${{ steps.get_version.outputs.VERSION }}.tar.gz
 
       - name: Create tarball (MacOS)


### PR DESCRIPTION
The CI script specified ubuntu-20.04 for building linux version of the release binary. However, the error happens when it is executed under ubuntu-22.04

```
error while loading shared libraries: libssl.so.1.1: cannot open shared object file: No such file or directory
```

The change here is to upgrade the ubuntu version so that the pre-built binary provided in the [Release](https://github.com/parallelchain-io/pchain-client-cli/releases) page can run on ubuntu-22.04. **After the merge, pre-built binary for ubuntu-20.04 is no longer supported.**